### PR TITLE
Removing TSFE usage (TYPO3 v13 compatibility)

### DIFF
--- a/Classes/Controller/AbstractController.php
+++ b/Classes/Controller/AbstractController.php
@@ -21,6 +21,7 @@ use JWeiland\Pforum\Domain\Repository\TopicRepository;
 use JWeiland\Pforum\Event\PostProcessFluidVariablesEvent;
 use JWeiland\Pforum\Event\PreProcessControllerActionEvent;
 use JWeiland\Pforum\Helper\FrontendGroupHelper;
+use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
@@ -45,6 +46,7 @@ class AbstractController extends ActionController
         protected readonly FrontendUserRepository $frontendUserRepository,
         protected readonly PersistenceManager $persistenceManager,
         protected readonly FrontendGroupHelper $frontendGroupHelper,
+        protected readonly Context $context,
     ) {
         $this->arguments = GeneralUtility::makeInstance(Arguments::class);
     }

--- a/Classes/Controller/PostController.php
+++ b/Classes/Controller/PostController.php
@@ -258,10 +258,8 @@ class PostController extends AbstractController
 
     protected function addFeUserToPost(Topic $topic, Post $post): void
     {
-        if (is_array($GLOBALS['TSFE']->fe_user->user) && $GLOBALS['TSFE']->fe_user->user['uid']) {
-            $user = $this->frontendUserRepository->findByUid(
-                (int)$GLOBALS['TSFE']->fe_user->user['uid'],
-            );
+        if ($feUserId = $this->context->getPropertyFromAspect('frontend.user', 'id')) {
+            $user = $this->frontendUserRepository->findByUid($feUserId);
             $post->setFrontendUser($user);
         } else {
             /* normally this should never be called, because the link to create a new entry was not displayed if user was not authenticated */

--- a/Classes/Controller/TopicController.php
+++ b/Classes/Controller/TopicController.php
@@ -247,10 +247,8 @@ class TopicController extends AbstractController
 
     protected function addFeUserToTopic(Forum $forum, Topic $topic): void
     {
-        if (is_array($GLOBALS['TSFE']->fe_user->user) && $GLOBALS['TSFE']->fe_user->user['uid']) {
-            $user = $this->frontendUserRepository->findByUid(
-                (int)$GLOBALS['TSFE']->fe_user->user['uid'],
-            );
+        if ($feUserId = $this->context->getPropertyFromAspect('frontend.user', 'id')) {
+            $user = $this->frontendUserRepository->findByUid($feUserId);
             $topic->setFrontendUser($user);
         } else {
             /* normally this should never be called, because the link to create a new entry was not displayed if user was not authenticated */

--- a/Classes/Helper/FrontendGroupHelper.php
+++ b/Classes/Helper/FrontendGroupHelper.php
@@ -11,37 +11,23 @@ declare(strict_types=1);
 
 namespace JWeiland\Pforum\Helper;
 
-use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
+use TYPO3\CMS\Core\Context\Context;
 
 /**
  * Helper to check FE groups for existing UID
  */
 class FrontendGroupHelper
 {
+    public function __construct(
+        private readonly Context $context,
+    ) {}
+
     public function uidExistsInGroupData(int $groupUid): bool
     {
         if ($groupUid === 0) {
             return false;
         }
 
-        return in_array($groupUid, $this->getGroupUidsOfCurrentUser(), true);
-    }
-
-    /**
-     * @return int[] List of group UIDs as integers
-     */
-    protected function getGroupUidsOfCurrentUser(): array
-    {
-        $groupUids = $this->getTypoScriptFrontendController()->fe_user->groupData['uid'];
-        if (!is_array($groupUids)) {
-            return [];
-        }
-
-        return array_map('intval', $groupUids);
-    }
-
-    protected function getTypoScriptFrontendController(): TypoScriptFrontendController
-    {
-        return $GLOBALS['TSFE'];
+        return in_array($groupUid, $this->context->getPropertyFromAspect('frontend.user', 'groupIds'), true);
     }
 }


### PR DESCRIPTION
TSFE was used to retrieve information about the fe_user (ID and groups). These parts of the code have been replaced with the use of [UserAspect](https://docs.typo3.org/permalink/t3coreapi:context-api-aspects-user).


[Deprecation: #105230 - TypoScriptFrontendController and $GLOBALS['TSFE']](https://docs.typo3.org/permalink/changelog:deprecation-105230-1728374467)
[Breaking: #102605 - TSFE->fe_user removed](https://docs.typo3.org/permalink/changelog:breaking-102605-1701772495)

Refs #27 