### PR TITLE
[Fix ]Remove usage of TSFE in Controllers and Helper

### DIFF
--- a/Classes/Controller/PostController.php
+++ b/Classes/Controller/PostController.php
@@ -264,13 +264,14 @@ class PostController extends AbstractController
         }
     }
 
-    protected function addFeUserToPost(Topic $topic, Post $post): ResponseInterface
+    protected function addFeUserToPost(Topic $topic, Post $post): ?ResponseInterface
     {
-        if (is_array($GLOBALS['TSFE']->fe_user->user) && $GLOBALS['TSFE']->fe_user->user['uid']) {
+        if (is_array($this->request->getAttribute('frontend.user')->user) && $this->request->getAttribute('frontend.user')->user['uid']) {
             $user = $this->frontendUserRepository->findByUid(
-                (int)$GLOBALS['TSFE']->fe_user->user['uid'],
+                (int)$this->request->getAttribute('frontend.user')->user['uid'],
             );
             $post->setFrontendUser($user);
+            return null;
         } else {
             /* normally this should never be called, because the link to create a new entry was not displayed if user was not authenticated */
             $this->addFlashMessage('You must be logged in before creating a post');

--- a/Classes/Controller/TopicController.php
+++ b/Classes/Controller/TopicController.php
@@ -249,13 +249,14 @@ class TopicController extends AbstractController
         }
     }
 
-    protected function addFeUserToTopic(Forum $forum, Topic $topic): ResponseInterface
+    protected function addFeUserToTopic(Forum $forum, Topic $topic): ?ResponseInterface
     {
-        if (is_array($GLOBALS['TSFE']->fe_user->user) && $GLOBALS['TSFE']->fe_user->user['uid']) {
+        if (is_array($this->request->getAttribute('frontend.user')->user) && $this->request->getAttribute('frontend.user')->user['uid']) {
             $user = $this->frontendUserRepository->findByUid(
-                (int)$GLOBALS['TSFE']->fe_user->user['uid'],
+                (int)$this->request->getAttribute('frontend.user')->user['uid'],
             );
             $topic->setFrontendUser($user);
+            return null;
         } else {
             /* normally this should never be called, because the link to create a new entry was not displayed if user was not authenticated */
             $this->addFlashMessage(

--- a/Classes/Helper/FrontendGroupHelper.php
+++ b/Classes/Helper/FrontendGroupHelper.php
@@ -11,13 +11,18 @@ declare(strict_types=1);
 
 namespace JWeiland\Pforum\Helper;
 
-use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
+use TYPO3\CMS\Core\Context\Context;
+use TYPO3\CMS\Core\Context\Exception\AspectNotFoundException;
 
 /**
  * Helper to check FE groups for existing UID
  */
 class FrontendGroupHelper
 {
+    public function __construct(
+        private readonly Context $context,
+    ) {}
+
     public function uidExistsInGroupData(int $groupUid): bool
     {
         if ($groupUid === 0) {
@@ -32,16 +37,16 @@ class FrontendGroupHelper
      */
     protected function getGroupUidsOfCurrentUser(): array
     {
-        $groupUids = $this->getTypoScriptFrontendController()->fe_user->groupData['uid'];
+        try {
+            $groupUids = $this->context->getPropertyFromAspect('frontend.user', 'groupIds');
+        } catch (AspectNotFoundException) {
+            return [];
+        }
+
         if (!is_array($groupUids)) {
             return [];
         }
 
         return array_map('intval', $groupUids);
-    }
-
-    protected function getTypoScriptFrontendController(): TypoScriptFrontendController
-    {
-        return $GLOBALS['TSFE'];
     }
 }


### PR DESCRIPTION
Usage of $GLOBALS['TSFE'] is not possible anymore in controllers. Remove it and use aspects of request instead.